### PR TITLE
Compile nmsynproxy with fPIC to allow shared objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ DIRLDP := pptk/ldp
 LCLDP := ldp
 MODULES += LDP
 
-CFLAGS := -g -O2 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Werror -std=gnu11
+CFLAGS := -g -O2 -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Werror -std=gnu11 -fPIC
 
 .PHONY: all clean distclean unit
 


### PR DESCRIPTION
Compile nmsynproxy with fPIC to allow shared objects